### PR TITLE
FW-2102: Stack Monitors

### DIFF
--- a/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
+++ b/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
@@ -861,8 +861,8 @@ uint32_t osThreadEnumerate (osThreadId_t *thread_array, uint32_t array_items) {
 #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
     task  = pvPortMalloc (count * sizeof(TaskStatus_t));
 #else
-    TaskStatus_t task_on_stack;
-    task = &task_on_stack;
+    TaskStatus_t task_on_stack[count];
+    task = &task_on_stack[0];
 #endif
 
     if (task != NULL) {


### PR DESCRIPTION
ticket: https://spanio.atlassian.net/browse/FW-2102

The main feature of this PR:
- Fixed `osThreadEnumerate`. The `task_on_stack` should be declared as an array of struct instead of a single struct.
