### PR TITLE
FW3: Extract os2_control_blocks from cmsis_os2.h

### DIFF
--- a/CMSIS/RTOS2/FreeRTOS/CMakeLists.txt
+++ b/CMSIS/RTOS2/FreeRTOS/CMakeLists.txt
@@ -3,8 +3,7 @@
 add_library(FW3_CMSIS_TARGET)
 target_sources(
   FW3_CMSIS_TARGET
-  PRIVATE ${FW3_CMSIS_DIR}/Source/cmsis_os1.c
-          ${FW3_CMSIS_DIR}/Source/cmsis_os2.c
+  PRIVATE ${FW3_CMSIS_DIR}/Source/cmsis_os2.c
           ${FW3_CMSIS_DIR}/Source/freertos_evr.c
           ${FW3_CMSIS_DIR}/Source/os_systick.c
           ${FW3_CMSIS_DIR}/Source/ARM/clib_arm.c)

--- a/CMSIS/RTOS2/FreeRTOS/Include/freertos_os2.h
+++ b/CMSIS/RTOS2/FreeRTOS/Include/freertos_os2.h
@@ -30,7 +30,7 @@
 
 #include "FreeRTOS.h"                   // ARM.FreeRTOS::RTOS:Core
 
-#include "freertos_os2_control_blocks.h"
+#include "os2_control_blocks.h"
 
 #if defined(_RTE_)
 #include "RTE_Components.h"             // Component selection

--- a/CMSIS/RTOS2/FreeRTOS/Include/os2_control_blocks.h
+++ b/CMSIS/RTOS2/FreeRTOS/Include/os2_control_blocks.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "FreeRTOS.h"
-#include "cmsis_os.h"
+#include "cmsis_os2.h"
 #include "freertos_mpool.h"
 #include "semphr.h"
 

--- a/CMSIS/RTOS2/FreeRTOS/Include1/cmsis_os.h
+++ b/CMSIS/RTOS2/FreeRTOS/Include1/cmsis_os.h
@@ -154,7 +154,6 @@
 #endif
  
 #include "cmsis_os2.h"
-#include "freertos_os2_control_blocks.h"
 
 #ifdef  __cplusplus
 extern "C"


### PR DESCRIPTION
As part of deprecating CMSIS RTOS v1 and avoiding IWYU problems, the inclusion of os2_control_blocks.h from cmsis_rtos2.h is removed.

This is also related to the work of reducing changes to CMSIS to a minimum (static allocation of memory pools).