### PR TITLE
FW3-155: Add unused parameter attribute to ARM_CM33 functions

### DIFF
--- a/Source/portable/GCC/ARM_CM33/non_secure/portasm.c
+++ b/Source/portable/GCC/ARM_CM33/non_secure/portasm.c
@@ -439,7 +439,7 @@ void SVC_Handler( void ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 }
 /*-----------------------------------------------------------*/
 
-void vPortAllocateSecureContext( uint32_t ulSecureStackSize ) /* __attribute__ (( naked )) */
+void vPortAllocateSecureContext( __attribute__( ( unused ) ) uint32_t ulSecureStackSize ) /* __attribute__ (( naked )) */
 {
     __asm volatile
     (
@@ -452,7 +452,7 @@ void vPortAllocateSecureContext( uint32_t ulSecureStackSize ) /* __attribute__ (
 }
 /*-----------------------------------------------------------*/
 
-void vPortFreeSecureContext( uint32_t * pulTCB ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
+void vPortFreeSecureContext( __attribute__( ( unused ) ) uint32_t * pulTCB ) /* __attribute__ (( naked )) PRIVILEGED_FUNCTION */
 {
     __asm volatile
     (


### PR DESCRIPTION
portasm.c in non_secure ARM_CM33 port generates some unused parameter warnings.

Suppressing this warning seems to require touching something from the parent repo, and touching this specific file seems like the lightest touch.