### PR TITLE
CMSIS: define osSysTickRateHz in CMSIS headers

### DIFF
--- a/CMSIS/RTOS2/FreeRTOS/Include/cmsis_os2_control_blocks.h
+++ b/CMSIS/RTOS2/FreeRTOS/Include/cmsis_os2_control_blocks.h
@@ -17,6 +17,11 @@
 #define osTickRateHz (configTICK_RATE_HZ)
 #define osMaxDelayTicks (portMAX_DELAY)
 
+#ifndef configSPAN_SYS_TICK_RATE_HZ
+#error configSPAN_SYS_TICK_RATE_HZ must be defined to a literal integer
+#endif
+#define osSysTickRateHz (configSPAN_SYS_TICK_RATE_HZ)
+
 typedef StaticTask_t osThreadControlBlock;
 typedef MemPool_t osMemoryPoolControlBlock;
 typedef StaticQueue_t osMessageQueueControlBlock;

--- a/CMSIS/RTOS2/FreeRTOS/Include/os2_control_blocks.h
+++ b/CMSIS/RTOS2/FreeRTOS/Include/os2_control_blocks.h
@@ -17,6 +17,11 @@
 #define osTickRateHz (configTICK_RATE_HZ)
 #define osMaxDelayTicks (portMAX_DELAY)
 
+#ifndef configSPAN_SYS_TICK_RATE_HZ
+#error configSPAN_SYS_TICK_RATE_HZ must be defined to a literal integer
+#endif
+#define osSysTickRateHz (configSPAN_SYS_TICK_RATE_HZ)
+
 typedef MemPool_t MemoryPoolControlBlock;
 typedef StaticQueue_t MessageQueueControlBlock;
 


### PR DESCRIPTION
This requires that the application define configSPAN_SYS_TICK_RATE_HZ. We primarily need it because we need an integer literal for defining a std::chrono-style clock based on the "SysTick".

Note that this updates both copies of the "control blocks" header. I'm not sure why we have two.

- [x] Must be merged along with https://github.com/spanio/FW3-Components/pull/244