### PR TITLE
G3P-X: Use FreeRTOS common app config header file

### DIFF
--- a/Source/include.cmake
+++ b/Source/include.cmake
@@ -1,8 +1,5 @@
 include_directories(${FW3_RTOS_DIR}/include)
 
-set(FREERTOS_CONFIG_FILE_DIRECTORY
-    ${FW3_APPLICATION_DIR}/Include
-    CACHE STRING "")
 set(FREERTOS_HEAP
     ${FW3_COMPONENTS_DIR}/Source/no_heap.c
     CACHE STRING "")


### PR DESCRIPTION
Use common FreeRTOSConfig.h
Needed in order to support this refactoring: https://github.com/spanio/Gen3-Panel/pull/555