### PR TITLE
G3P-22238: Revert to opt-in privilege model in osThreadNew

### DIFF
--- a/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
+++ b/CMSIS/RTOS2/FreeRTOS/Source/cmsis_os2.c
@@ -584,11 +584,10 @@ osThreadId_t osThreadNew (osThreadFunc_t func, void *argument, const osThreadAtt
         NS-side privilege separation is a security boundary, not just a
         robustness feature. */
       #if (configENABLE_MPU == 1)
-        /* Default to privileged; only drop to unprivileged if osThreadUnprivileged
-           is explicitly requested. This matches our architecture where all internal
-           service threads are privileged and unprivileged tasks are created directly
-           via xTaskCreateRestrictedStatic. */
-        if ((attr->attr_bits & osThreadUnprivileged) != osThreadUnprivileged) {
+        /* Opt-in privilege: only set portPRIVILEGE_BIT if osThreadPrivileged is
+           explicitly requested. Threads created without osThreadPrivileged run
+           unprivileged, which is the correct default when configENABLE_MPU=1. */
+        if ((attr->attr_bits & osThreadPrivileged) == osThreadPrivileged) {
           prio |= portPRIVILEGE_BIT;
         }
       #endif


### PR DESCRIPTION
## Summary

- Restore the original opt-in check (osThreadPrivileged must be explicitly set) instead of the opt-out inversion. With CREATE_PRIVILEGED_THREAD_ATTRIBUTES setting osThreadPrivileged on all service threads and CREATE_THREAD_ATTRIBUTES leaving it unset for unprivileged tasks, opt-in is the correct and cleaner default.

## Context

This work supports G3P-22238, which creates an unprivileged FreeRTOS task on STM32H573 (Cortex-M33 with TrustZone). The CMSIS-RTOS2 wrapper previously had no mechanism to create unprivileged tasks via the \`osThreadNew\` API — all threads were created privileged regardless of the \`osThreadUnprivileged\` attribute flag.

## Test plan

- [x] Branch firmware (STM32H573, \`configENABLE_MPU=1\`) builds clean
- [x] Counter task runs as unprivileged on Branch hardware without MPU faults
- [ ] System regression tests completed without issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)